### PR TITLE
Emojis gets properly count

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can be installed by adding `sms_part_counter` to your list of depend
 ```elixir
 def deps do
   [
-    {:sms_part_counter, "~> 0.1.3"}
+    {:sms_part_counter, git: "https://github.com/rum-and-code/sms-counter.git", tag: "v0.1.7"},
   ]
 end
 ```
@@ -20,7 +20,7 @@ end
 ## Usage
 
 ```elixir
-iex> SmsPartCounter.count_parts("blah blah blah")
+iex> SmsPartCounter.count_parts("Lorem ipsum dolor sit amet, consectetur adipiscing elit")
 %{
   "encoding" => "gsm_7bit",
   "parts" => 1

--- a/lib/sms_part_counter.ex
+++ b/lib/sms_part_counter.ex
@@ -26,8 +26,11 @@ defmodule SmsPartCounter do
   """
   @spec count(binary) :: integer()
   def count(str) when is_binary(str) do
-    String.codepoints(str)
-    |> Enum.count()
+    codepoints = String.to_charlist(str)
+
+    codepoints
+    |> Enum.count(fn cp -> cp > 0xFFFF end)
+    |> then(&(&1 + Enum.count(codepoints)))
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,14 +4,14 @@ defmodule SmsPartCounter.MixProject do
   def project do
     [
       app: :sms_part_counter,
-      version: "0.1.6",
+      version: "0.1.7",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),
       package: package(),
-      source_url: "https://github.com/m4hi2/sms-counter",
-      homepage_url: "https://github.com/m4hi2/sms-counter"
+      source_url: "https://github.com/rum-and-code/sms-counter",
+      homepage_url: "https://github.com/rum-and-code/sms-counter"
     ]
   end
 
@@ -35,8 +35,9 @@ defmodule SmsPartCounter.MixProject do
 
   defp package() do
     [
+      maintainers: ["Rum&Code"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/m4hi2/sms-counter"}
+      links: %{"GitHub" => "https://github.com/rum-and-code/sms-counter"}
     ]
   end
 end


### PR DESCRIPTION
I made an observation while experimenting with this module that when I used emojis, the number of segments generated by Twilio and other online calculators differed. The reason for this discrepancy was traced to the `String.codepoints/1` function. Although this function is expected to provide all codepoints, it treats emojis as single codepoints, despite being composed of two codepoints. To resolve this issue, I modified the `SmsPartCounter.count/1` function to consider this behavior.